### PR TITLE
Retrieve file properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ Simple test that checks whether a file or directory exists. This indicates it in
 ### get(path:  string):  Promise<string  |  Buffer>
 Gets a file as a string/Buffer.
 
+### getProperties(path: string):  Promise<any>
+Retrieves properties of a file.
+
 ## Exceptions
 
 ### NotFoundError

--- a/README.md
+++ b/README.md
@@ -42,8 +42,11 @@ This saves a string at `path`.
 
 Throws a `NotFoundError` if the path to the requested directory does not exist.
 
-### rename(from:  string, to:  string):  Promise\<void\>
+### rename(fromFullPath:  string, toFileName:  string):  Promise\<void\>
 This allows to rename files or directories.
+
+### move(fromFullPath:  string, toFullPath:  string):  Promise\<void\>
+This allows to move files or entire directories.
 
 ### getWriteStream(path:  string):  Promise\<Stream.Writable\>
 Gets a write stream to a remote Nextcloud `path`.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "helpbox": "^7.1.1",
-    "webdav-client": "https://github.com:tentwentyfour/npm-WebDAV-Client",
+    "webdav-client": "https://github.com:tentwentyfour/npm-WebDAV-Client.git#0c6fc799b79f467a0e6d1656f596cd4b39bb3d9b"
   },
   "types": "./compiled/source/client.d.ts",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "helpbox": "^7.1.1",
-    "webdav-client": "^1.4.2"
+    "webdav-client": "https://github.com:tentwentyfour/npm-WebDAV-Client",
   },
   "types": "./compiled/source/client.d.ts",
   "devDependencies": {

--- a/source/client.ts
+++ b/source/client.ts
@@ -4,6 +4,7 @@ import * as Stream from "stream";
 import {
   configureWebdavConnection,
   createFolderHierarchy,
+  getFolderFileDetails,
   checkConnectivity,
   getWriteStream,
   getProperties,
@@ -14,6 +15,7 @@ import {
   rename,
   remove,
   exists,
+  move,
   put,
   get
 } from "./webdav";
@@ -27,6 +29,7 @@ import {
 export class NextcloudClient extends NextcloudClientProperties implements NextcloudClientInterface {
   configureWebdavConnection = configureWebdavConnection;
   createFolderHierarchy     = createFolderHierarchy;
+  getFolderFileDetails      = getFolderFileDetails;
   checkConnectivity         = checkConnectivity;
   getWriteStream            = getWriteStream;
   getProperties             = getProperties;
@@ -37,6 +40,7 @@ export class NextcloudClient extends NextcloudClientProperties implements Nextcl
   rename                    = rename;
   remove                    = remove;
   exists                    = exists;
+  move                      = move;
   put                       = put;
   get                       = get;
 

--- a/source/client.ts
+++ b/source/client.ts
@@ -6,6 +6,7 @@ import {
   createFolderHierarchy,
   checkConnectivity,
   getWriteStream,
+  getProperties,
   getReadStream,
   touchFolder,
   pipeStream,
@@ -28,6 +29,7 @@ export class NextcloudClient extends NextcloudClientProperties implements Nextcl
   createFolderHierarchy     = createFolderHierarchy;
   checkConnectivity         = checkConnectivity;
   getWriteStream            = getWriteStream;
+  getProperties             = getProperties;
   getReadStream             = getReadStream;
   touchFolder               = touchFolder;
   pipeStream                = pipeStream;

--- a/source/types.ts
+++ b/source/types.ts
@@ -13,12 +13,12 @@ export class NextcloudClientProperties {
 export interface NextcloudClientInterface extends NextcloudClientProperties {
   configureWebdavConnection(options: ConnectionOptions): void;
   pipeStream(path: string, stream: Stream.Readable):     Promise<void>;
+  rename(fromFullPath: string, toFileName: string):      Promise<void>;
+  move(fromFullPath: string, toFullPath: string):        Promise<void>;
   as(username: string, password: string):                NextcloudClientInterface;
   createFolderHierarchy(path: string):                   Promise<void>;
   put(path: string, content: string):                    Promise<void>;
   getFolderFileDetails(path: string):                    Promise<FileDetails[]>;
-  rename(from: string, to: string):                      Promise<void>;
-  move(from: string, to: string):                        Promise<void>;
   getWriteStream(path: string):                          Promise<Stream.Writable>;
   getReadStream(path: string):                           Promise<Stream.Readable>;
   getProperties(path: string):                           Promise<any>;

--- a/source/types.ts
+++ b/source/types.ts
@@ -22,6 +22,7 @@ export interface NextcloudClientInterface extends NextcloudClientProperties {
   rename(from: string, to: string):                      Promise<void>;
   getWriteStream(path: string):                          Promise<Stream.Writable>;
   getReadStream(path: string):                           Promise<Stream.Readable>;
+  getProperties(path: string):                           Promise<any>;
   touchFolder(path: string):                             Promise<void>;
   remove(path: string):                                  Promise<void>;
   exists(path: string):                                  Promise<boolean>;

--- a/source/types.ts
+++ b/source/types.ts
@@ -2,9 +2,7 @@ import * as Webdav from "webdav-client";
 import * as Stream from "stream";
 
 export type AsyncFunction = (...parameters) => Promise<any>;
-
-export type ReadDirOptions = Webdav.ConnectionReaddirOptions;
-export type ReadDirResult  = string | Webdav.ConnectionReaddirComplexResult;
+export type FileDetails   = Webdav.ConnectionReaddirComplexResult;
 
 export class NextcloudClientProperties {
   webdavConnection: Webdav.Connection;
@@ -15,15 +13,17 @@ export class NextcloudClientProperties {
 export interface NextcloudClientInterface extends NextcloudClientProperties {
   configureWebdavConnection(options: ConnectionOptions): void;
   pipeStream(path: string, stream: Stream.Readable):     Promise<void>;
-  getFiles(path: string, options?: ReadDirOptions):      Promise<[ReadDirResult]>;
   as(username: string, password: string):                NextcloudClientInterface;
   createFolderHierarchy(path: string):                   Promise<void>;
   put(path: string, content: string):                    Promise<void>;
+  getFolderFileDetails(path: string):                    Promise<FileDetails[]>;
   rename(from: string, to: string):                      Promise<void>;
+  move(from: string, to: string):                        Promise<void>;
   getWriteStream(path: string):                          Promise<Stream.Writable>;
   getReadStream(path: string):                           Promise<Stream.Readable>;
   getProperties(path: string):                           Promise<any>;
   touchFolder(path: string):                             Promise<void>;
+  getFiles(path: string):                                Promise<string[]>;
   remove(path: string):                                  Promise<void>;
   exists(path: string):                                  Promise<boolean>;
   checkConnectivity():                                   Promise<boolean>;

--- a/source/types.ts
+++ b/source/types.ts
@@ -3,6 +3,9 @@ import * as Stream from "stream";
 
 export type AsyncFunction = (...parameters) => Promise<any>;
 
+export type ReadDirOptions = Webdav.ConnectionReaddirOptions;
+export type ReadDirResult  = string | Webdav.ConnectionReaddirComplexResult;
+
 export class NextcloudClientProperties {
   webdavConnection: Webdav.Connection;
   username:         string;
@@ -12,6 +15,7 @@ export class NextcloudClientProperties {
 export interface NextcloudClientInterface extends NextcloudClientProperties {
   configureWebdavConnection(options: ConnectionOptions): void;
   pipeStream(path: string, stream: Stream.Readable):     Promise<void>;
+  getFiles(path: string, options?: ReadDirOptions):      Promise<[ReadDirResult]>;
   as(username: string, password: string):                NextcloudClientInterface;
   createFolderHierarchy(path: string):                   Promise<void>;
   put(path: string, content: string):                    Promise<void>;
@@ -19,7 +23,6 @@ export interface NextcloudClientInterface extends NextcloudClientProperties {
   getWriteStream(path: string):                          Promise<Stream.Writable>;
   getReadStream(path: string):                           Promise<Stream.Readable>;
   touchFolder(path: string):                             Promise<void>;
-  getFiles(path: string):                                Promise<string[]>;
   remove(path: string):                                  Promise<void>;
   exists(path: string):                                  Promise<boolean>;
   checkConnectivity():                                   Promise<boolean>;

--- a/source/webdav.ts
+++ b/source/webdav.ts
@@ -6,7 +6,9 @@ import * as Stream      from "stream";
 import {
   NextcloudClientInterface,
   ConnectionOptions,
-  AsyncFunction
+  AsyncFunction,
+  ReadDirResult,
+  ReadDirOptions
 } from "./types";
 
 import {
@@ -68,10 +70,10 @@ async function rawGet(sanePath: string): Promise<string> {
   return await promisifiedGet.call(self.webdavConnection, sanePath);
 }
 
-async function rawGetFiles(sanePath: string): Promise<string[]> {
+async function rawGetFiles(sanePath: string, options?: ReadDirOptions): Promise<[ReadDirResult]> {
   const self: NextcloudClientInterface = this;
 
-  const files: string[] = await promisifiedReaddir.call(self.webdavConnection, sanePath);
+  const files: [ReadDirResult] = await promisifiedReaddir.call(self.webdavConnection, sanePath, options);
 
   if (!Array.isArray(files)) {
     throw new NotReadyError;

--- a/source/webdav.ts
+++ b/source/webdav.ts
@@ -21,14 +21,15 @@ import {
 
 const sanitizePath = encodeURI;
 
-const promisifiedPut       = promisify(Webdav.Connection.prototype.put);
-const promisifiedGet       = promisify(Webdav.Connection.prototype.get);
-const promisifiedMove      = promisify(Webdav.Connection.prototype.move);
-const promisifiedMkdir     = promisify(Webdav.Connection.prototype.mkdir);
-const promisifiedExists    = promisify(Webdav.Connection.prototype.exists);
-const promisifiedDelete    = promisify(Webdav.Connection.prototype.delete);
-const promisifiedReaddir   = promisify(Webdav.Connection.prototype.readdir);
-const promisifiedPreStream = promisify(Webdav.Connection.prototype.prepareForStreaming);
+const promisifiedPut           = promisify(Webdav.Connection.prototype.put);
+const promisifiedGet           = promisify(Webdav.Connection.prototype.get);
+const promisifiedMove          = promisify(Webdav.Connection.prototype.move);
+const promisifiedMkdir         = promisify(Webdav.Connection.prototype.mkdir);
+const promisifiedExists        = promisify(Webdav.Connection.prototype.exists);
+const promisifiedDelete        = promisify(Webdav.Connection.prototype.delete);
+const promisifiedReaddir       = promisify(Webdav.Connection.prototype.readdir);
+const promisifiedPreStream     = promisify(Webdav.Connection.prototype.prepareForStreaming);
+const promisifiedGetProperties = promisify(Webdav.Connection.prototype.getProperties);
 
 async function rawGetReadStream(sanePath: string): Promise<Stream.Readable> {
   const self: NextcloudClientInterface = this;
@@ -80,6 +81,12 @@ async function rawGetFiles(sanePath: string, options?: ReadDirOptions): Promise<
   }
 
   return files;
+}
+
+async function rawGetProperties(sanePath: string): Promise<any> {
+  const self: NextcloudClientInterface = this;
+
+  return promisifiedGetProperties.call(self.webdavConnection, sanePath);
 }
 
 async function rawRename(saneFrom: string, newName: string): Promise<void> {
@@ -159,6 +166,7 @@ async function rawPipeStream(sanePath: string, stream: Stream): Promise<void> {
 
 export const createFolderHierarchy = clientFunction(rawCreateFolderHierarchy);
 export const getWriteStream        = clientFunction(rawGetWriteStream);
+export const getProperties         = clientFunction(rawGetProperties);
 export const getReadStream         = clientFunction(rawGetReadStream);
 export const touchFolder           = clientFunction(rawTouchFolder);
 export const pipeStream            = clientFunction(rawPipeStream);


### PR DESCRIPTION
- getFiles allows for passing ReadDir options which enables users to retrieve a list of file properties instead of simply a list of names
  - the properties enable differentiation between folders and files
- an additional getProperties method allows to retrieve contentlength and contenttype meta data
  - the actual data returned is defined by the WebDAV server, nextcloud does return the above
- for nextcloud the readDir request does not return a creationdate property which is expected by npm-WebDAV-client, which will cause it throw an error
  - changes where made to the later library so that we check for the existence of a creationdate property on the response and if that fails use the modification date instead (hence we switch to tentwentyfour/npm-WebDAV-client as a dependency)
  - this might be nextcloud specific, according to [rfc4918](https://tools.ietf.org/html/rfc4918#section-15.1) this property should be defined
- the source needs to be recompiled